### PR TITLE
Parameterize Makefile and xml to allow for non-root install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 ifdef user
 INSTALL_DIR=$(HOME)/usr/share/ibus-uniemoji
 COMPONENT_DIR=$(HOME)/.config/ibus/component
-CONFIG_DIR=$(HOME)/.config/unimoji
+CONFIG_DIR=$(HOME)/.config/uniemoji
 else
 INSTALL_DIR=/usr/share/ibus-uniemoji
 COMPONENT_DIR=/usr/share/ibus/component

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,51 @@
-# only really known to work on ubuntu, if you're using anything else, hopefully
-# it should at least give you a clue how to install it by hand
-# TODO: parameterize this and the xml file (maybe scons?)
+# Only really known to work on Ubuntu and Debian 9 (stretch). If you're using
+# anything else, hopefully it should at least give you a clue how to install it
+# by hand.
+#
+# TODO: ensure "make uninstall" does not clobber a customized custom.json
+# TODO: make "install" better at detecting whether IBUS_COMPONENT_PATH is correct
+# TODO: package properly for various systems
+
+ifdef user
+INSTALL_DIR=$(HOME)/usr/share/ibus-uniemoji
+COMPONENT_DIR=$(HOME)/.config/ibus/component
+CONFIG_DIR=$(HOME)/.config/unimoji
+else
+INSTALL_DIR=/usr/share/ibus-uniemoji
+COMPONENT_DIR=/usr/share/ibus/component
+CONFIG_DIR=/etc/xdg/uniemoji
+endif
+
+default:
+	# This software has no compilation step. Just run either:
+	#
+	# 	sudo make install
+	#
+	# to install it system-wide, or
+	#
+	# 	make install user=1
+	#
+	# to install it for the current user only (which does not require root
+	# permission).
+	#
+	# Likewise, 'make uninstall' or 'make uninstall user=1' respectively will
+	# undo the changes.
+
 install:
-	mkdir -p /usr/share/ibus-uniemoji /etc/xdg/uniemoji
-	cp uniemoji.py uniemoji.svg UnicodeData.txt /usr/share/ibus-uniemoji
-	chmod a+x /usr/share/ibus-uniemoji/uniemoji.py
-	cp uniemoji.xml /usr/share/ibus/component
-	cp custom.json /etc/xdg/uniemoji
+	mkdir -p $(INSTALL_DIR) $(CONFIG_DIR) $(COMPONENT_DIR)
+	cp uniemoji.py uniemoji.svg UnicodeData.txt $(INSTALL_DIR)/
+	chmod a+x $(INSTALL_DIR)/uniemoji.py
+	sed -e 's%INSTALL_DIR%$(INSTALL_DIR)%' uniemoji.xml > $(COMPONENT_DIR)/uniemoji.xml
+	cp custom.json $(CONFIG_DIR)/custom.json
+	@if [ "$(COMPONENT_DIR)" != "/usr/share/ibus/component" ]; then\
+		echo;\
+		echo "NOTE: you must set IBUS_COMPONENT_PATH; for example in ~/.xprofile:";\
+		echo;\
+		echo "export IBUS_COMPONENT_PATH=$(COMPONENT_DIR):/usr/share/ibus/component";\
+		echo;\
+		fi
 
 uninstall:
-	rm -rf /usr/share/ibus-uniemoji
-	rm -rf /etc/xdg/uniemoji
-	rm -f /usr/share/ibus/component/uniemoji.xml
+	rm -rf $(INSTALL_DIR)
+	rm -rf $(CONFIG_DIR)
+	rm -f $(COMPONENT_DIR)/uniemoji.xml

--- a/uniemoji.xml
+++ b/uniemoji.xml
@@ -7,7 +7,7 @@
     <license>GPL</license>
     <author>Lalo Martins &lt;lalo.martins@gmail.com&gt;</author>
     <homepage>https://github.com/lalomartins/ibus-uniemoji</homepage>
-    <exec>/usr/bin/python2 /usr/share/ibus-uniemoji/uniemoji.py --ibus</exec>
+    <exec>/usr/bin/python2 INSTALL_DIR/uniemoji.py --ibus</exec>
     <textdomain>uniemoji</textdomain>
     <engines>
         <engine>
@@ -17,7 +17,7 @@
             <language></language>
             <license>GPL</license>
             <author>Lalo Martins &lt;lalo.martins@gmail.com&gt;</author>
-            <icon>/usr/share/ibus-uniemoji/uniemoji.svg</icon>
+            <icon>INSTALL_DIR/uniemoji.svg</icon>
             <layout>default</layout>
             <layout_variant>default</layout_variant>
             <layout_option>default</layout_option>


### PR DESCRIPTION
For your kind consideration, this patch:

- makes it so "install" is not the default makefile target (which is surprising and probably unwanted.)
- allows one to specify "user=1" argument to "make", changing some defaults to allow for non-root installation for the current user only.