### PR TITLE
Add the 'Pd' unicode group to allow for en and em dashes.

### DIFF
--- a/uniemoji.py
+++ b/uniemoji.py
@@ -130,7 +130,7 @@ class UniEmoji(IBus.Engine):
                 code = int(code, 16)
                 if not in_range(code):
                     continue
-                if category not in ('Sm', 'So', 'Po'):
+                if category not in ('Sm', 'So', 'Po', 'Pd'):
                     continue
                 self.table[name.lower()] = unichr(code)
 


### PR DESCRIPTION
One of the main things I wanted ibus-uniemoji to do is, along with Unicode pictographs, let me write proper em- and en-dashes. This change enables that, by allowing the "Pd" Unicode group. (Whatever that means.)