### PR TITLE
Currency symbols

### DIFF
--- a/uniemoji.py
+++ b/uniemoji.py
@@ -61,6 +61,7 @@ del n
 __base_dir__ = os.path.dirname(__file__)
 
 VALID_CATEGORIES = (
+    'Sc', # Symbol, currency
     'Sm', # Symbol, math
     'So', # Symbol, other
     'Pd', # Punctuation, dash
@@ -68,10 +69,19 @@ VALID_CATEGORIES = (
 )
 
 VALID_RANGES = (
+    (0x0024, 0x0024), # DOLLAR SIGN
+    (0x00a2, 0x00a5), # CENT SIGN, POUND SIGN, CURRENCY SIGN, YEN SIGN
+    (0x058f, 0x058f), # ARMENIAN DRAM SIGN
+    (0x060b, 0x060b), # AFGHANI SIGN
+    (0x09f2, 0x09f3), # BENGALI RUPEE MARK, BENGALI RUPEE SIGN
+    (0x09fb, 0x09fb), # BENGALI GANDA MARK
+    (0x0af1, 0x0af1), # GUJARATI RUPEE SIGN
+    (0x0bf9, 0x0bf9), # TAMIL RUPEE SIGN
+    (0x0e3f, 0x0e3f), # THAI CURRENCY SYMBOL BAHT
+    (0x17db, 0x17db), # KHMER CURRENCY SYMBOL RIEL
     (0x2000, 0x206f), # General Punctuation, Layout Controls, Invisible Operators
     (0x2070, 0x209f), # Superscripts and Subscripts
     (0x20a0, 0x20cf), # Currency Symbols
-    (0x20ac, 0x20ac), # Euro Sign
     (0x20d0, 0x20ff), # Combining Diacritical Marks for Symbols
     (0x2100, 0x214f), # Additional Squared Symbols, Letterlike Symbols
     (0x2150, 0x218f), # Number Forms
@@ -100,6 +110,10 @@ VALID_RANGES = (
     (0x2980, 0x29ff), # Miscellaneous Mathematical Symbols-B
     (0x2a00, 0x2aff), # Supplemental Mathematical Operators
     (0x2b00, 0x2bff), # Additional Shapes, Miscellaneous Symbols and Arrows
+    (0xa838, 0xa838), # NORTH INDIC RUPEE MARK
+    (0xfdfc, 0xfdfc), # RIAL SIGN
+    (0xfe69, 0xfe69), # SMALL DOLLAR SIGN
+    (0xff01, 0xff60), # Fullwidth symbols and currency signs
     (0x1f300, 0x1f5ff), # Miscellaneous Symbols and Pictographs
     (0x1f600, 0x1f64f), # Emoticons
     (0x1f650, 0x1f67f), # Ornamental Dingbats


### PR DESCRIPTION
Currency symbols didn’t work because 'Sc' was not in VALID_CATEGORIES.

Was that intentional? 

I think currency symbols are useful and if this was just an oversight it is probably
a good idea to make them work.